### PR TITLE
Sanity token is exposed to the public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,8 @@ yarn-error.log*
 # local env files
 .env*.local
 
+# prod env files
+.env
+
 # vercel
 .vercel


### PR DESCRIPTION
Please be aware that your sanity token is exposed to the public and it's important to add .env to the gitignore file to keep the commit history clean.